### PR TITLE
Add configuration as to where to add the polyfill script

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,12 @@ module.exports = function() {
       ua: 'foo',
       callback: 'bar',
       unknown: 'baz',
-      rum: 0
+      rum: 0,
+
+      // Configure where the polyfill script will be added to the index.html file.
+      // Default is `head` ember-cli provides `head`, `head-footer`, `body` and `body-footer`
+      // FYI you need to load the polyfill before your app.js file
+      contentFor: 'body-footer'
     }
   };
 };

--- a/index.js
+++ b/index.js
@@ -7,11 +7,13 @@ module.exports = {
   name: 'polyfill-io',
 
   contentFor(type, config) {
-    if (type !== 'head') {
+    const polyfillConfig = config['polyfill-io'] || {};
+    const contentForType = polyfillConfig.contentFor || 'head';
+
+    if (type !== contentForType) {
       return;
     }
 
-    const polyfillConfig = config['polyfill-io'] || {};
     const src = buildSrc(polyfillConfig);
 
     debug(`Using script src: ${src}`);


### PR DESCRIPTION
This PR allows the developer to move the polyfill script to any `content-for` hooks in the index.html

We are fastbooting and rehydrating our app and want all the js to be in the footer.

Cheers 